### PR TITLE
different fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CUDA_INC=/pkgs_local/cuda-5.5/include
 CUDA_LIB=/pkgs_local/cuda-5.5/lib64
 #####################################
 CXX = g++
-LIBFLAGS = -L$(LIB) -L$(CUDA_LIB) -L/u/nitish/convnet/cudamat
+LIBFLAGS = -L$(LIB) -L$(CUDA_LIB) -L./cudamat
 CPPFLAGS = -I$(INC) -I$(CUDA_INC) -I$(SRC) -Ideps
 LINKFLAGS = -lhdf5 -ljpeg -lX11 -lpthread -lprotobuf -lcublas -ldl -lgomp -lcudamat -lcudamat_conv -lcudart -Wl,-rpath='$$ORIGIN/../cudamat'
 CXXFLAGS = -O2 -std=c++0x -mtune=native -Wall -Wno-unused-result -Wno-sign-compare -fopenmp

--- a/cpu/convnet_cpu.cc
+++ b/cpu/convnet_cpu.cc
@@ -355,7 +355,7 @@ void Edge::LoadParameters(hid_t file) {
     int kernel_size = (edge_type_ == config::Edge::FC) ? image_size_ : kernel_size_;
     CPUMatrix::Transpose(data, weights_.GetData(), num_output_channels_,
                          kernel_size, kernel_size, num_input_channels_);
-    delete data;
+    delete[] data;
     ss.str("");
   }
   if (bias_.GetSize() > 0) {

--- a/cpu/cpuconv.cc
+++ b/cpu/cpuconv.cc
@@ -21,7 +21,7 @@ CPUMatrix::CPUMatrix(const int rows, const int cols): rows_(rows), cols_(cols) {
 }
 
 void CPUMatrix::FreeMemory() {
-  if (rows_ * cols_ > 0) delete data_;
+  if (rows_ * cols_ > 0) delete[] data_;
 }
 
 void CPUMatrix::AllocateMemory(int rows, int cols) {

--- a/cpu/extract_representation_cpu.cc
+++ b/cpu/extract_representation_cpu.cc
@@ -180,7 +180,7 @@ int main(int argc, char** argv) {
       start_t = end_t;
       cout << endl;
     }
-    delete data;
+    delete[] data;
     for (ofstream& f : outf) {
       f.close();
     }

--- a/src/convnet.h
+++ b/src/convnet.h
@@ -18,7 +18,7 @@ class ConvNet {
   * Instantiate a model using the config in model_file.
   */ 
   ConvNet(const string& model_file);
-  ~ConvNet();
+  virtual ~ConvNet();
   virtual void SetupDataset(const string& train_data_config_file);
   virtual void SetupDataset(const string& train_data_config_file, const string& val_data_config_file);
 

--- a/src/datahandler.cc
+++ b/src/datahandler.cc
@@ -339,7 +339,7 @@ DataIterator* DataIterator::ChooseDataIterator(const config::DataStreamConfig& c
       it = new BoundingBoxIterator(config);
       break;
     default:
-      cerr << "Unknown data type " << config.data_type() << endl;
+      cerr << "Unknown data type " << (int)config.data_type() << endl;
       exit(1);
   }
   return it;
@@ -570,7 +570,7 @@ HDF5DataIterator<T>::HDF5DataIterator(const config::DataStreamConfig& config):
 
 template <typename T>
 HDF5DataIterator<T>::~HDF5DataIterator() {
-  delete buf_;
+  delete[] buf_;
   H5Tclose(type_);
   H5Sclose(m_dataspace_);
   H5Pclose(dapl_id_);
@@ -593,7 +593,7 @@ void HDF5DataIterator<T>::Get(float* data_ptr, const int row) const {
   for (int i = 0; i < num_dims_; i++) {
     data_ptr[i] = static_cast<float>(buf[i]);
   }
-  delete buf;
+  delete[] buf;
 }
 
 template <typename T>
@@ -641,7 +641,7 @@ ImageDataIterator::ImageDataIterator(const config::DataStreamConfig& config):
 }
 
 ImageDataIterator::~ImageDataIterator() {
-  delete buf_;
+  delete[] buf_;
   delete it_;
 }
 
@@ -679,7 +679,7 @@ void ImageDataIterator::Get(float* data_out, const int row) const {
   for (int i = 0; i < image_size_ * image_size_ * num_colors_; i++) {
     data_out[i] = static_cast<float>(buf[i]);
   }
-  delete buf;
+  delete[] buf;
 }
 
 SlidingWindowDataIterator::SlidingWindowDataIterator(
@@ -699,7 +699,7 @@ SlidingWindowDataIterator::SlidingWindowDataIterator(
 }
 
 SlidingWindowDataIterator::~SlidingWindowDataIterator() {
-  delete buf_;
+  delete[] buf_;
   delete it_;
 }
 
@@ -777,7 +777,7 @@ CropDataIterator::CropDataIterator(const config::DataStreamConfig& config):
 }
 
 CropDataIterator::~CropDataIterator() {
-  delete buf_;
+  delete[] buf_;
   delete it_;
 }
 
@@ -831,7 +831,7 @@ TextDataIterator::TextDataIterator(const config::DataStreamConfig& config):
 }
 
 TextDataIterator::~TextDataIterator() {
-  delete data_;
+  delete[] data_;
 }
 
 void TextDataIterator::Get(float* data_out, const int row) const {

--- a/src/datawriter.cc
+++ b/src/datawriter.cc
@@ -81,7 +81,7 @@ void DataWriter::WriteHDF5(Matrix& m, const string& dataset, int numcases, bool 
     }
     H5Dwrite(s.dataset, H5T_NATIVE_UCHAR, mem_dataspace, s.dataspace, H5P_DEFAULT,
              uchar_buf);
-    delete uchar_buf;
+    delete[] uchar_buf;
   } else {
     H5Dwrite(s.dataset, H5T_NATIVE_FLOAT, mem_dataspace, s.dataspace, H5P_DEFAULT,
             data);

--- a/src/datawriter.h
+++ b/src/datawriter.h
@@ -7,7 +7,7 @@
 class DataWriter {
  public:
   DataWriter(const config::FeatureExtractorConfig config);
-  ~DataWriter();
+  virtual ~DataWriter();
   void SetNumDims(const string& name, const int num_dims);
   void SetDataSetSize(int dataset_size);
   virtual void Write(vector<Layer*>& layers, int numcases);

--- a/src/edge.h
+++ b/src/edge.h
@@ -14,7 +14,7 @@ class Edge {
  public:
   /** Instatntiate an Edge from the config.*/
   Edge(const config::Edge& edge_config);
-  ~Edge();
+  virtual ~Edge();
   
   /** Allocate memory for the model.
    * @param fprop_only If true, does not allocate memory needed for optimization.

--- a/src/jpeg2hdf5.cc
+++ b/src/jpeg2hdf5.cc
@@ -73,7 +73,7 @@ int main(int argc, char ** argv) {
     cout << endl;
     H5Sclose(mem_dataspace);
     H5Fclose(file);
-    delete image_buf;
+    delete[] image_buf;
   } catch (TCLAP::ArgException &e)  {
     cerr << "error: " << e.error() << " for arg " << e.argId() << endl;
   }

--- a/src/layer.h
+++ b/src/layer.h
@@ -10,7 +10,7 @@ class Layer {
  public:
   /** Instantiate a layer from config. */ 
   Layer(const config::Layer& config);
-  ~Layer();
+  virtual ~Layer();
 
   /** Allocate memory for storing the state and derivative at this layer.
    * @param batch_size The mini-batch size.

--- a/src/matrix.cc
+++ b/src/matrix.cc
@@ -237,7 +237,7 @@ void Matrix::PrintToFile(const string& filename) {
     cerr << "Error: Could not copy to host : " << GetStringError(err_code) << endl;
     exit(1);
   }
-  ofstream f(filename, ios::out);
+  ofstream f(filename.c_str(), ios::out);
   for (int i = 0; i < mat_.size[0]; i++) {
     for (int j = 0; j < mat_.size[1]; j++) {
       f << mat_.data_host[j * mat_.size[0] + i] << " ";

--- a/src/optimizer.h
+++ b/src/optimizer.h
@@ -8,7 +8,7 @@
 class Optimizer {
  public:
   Optimizer(const config::Optimizer& optimizer_config);
-  ~Optimizer();
+  virtual ~Optimizer();
 
   // Allocate any memory needed.
   virtual void AllocateMemory(const int rows, const int cols);

--- a/src/util.cc
+++ b/src/util.cc
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <ctime>
 #include <sstream>
+#include <limits>
 
 using namespace std;
 


### PR DESCRIPTION
Hello, @nitishsrivastava 

I created module for opencv using this library code: https://github.com/avdmitry/opencv_contrib/tree/deepmodels/modules/graphmodels
I don't know whether it will be useful for someone, but maybe opencv community will participate in this library development, at least I :)

In this PR I fixed some warnings, which I got and two issues:
1. I also got warnings for this: class which has virtual function usually also should have virtual destructor.
2. For operator new[] should be used operator delete[], otherwise there appear memory leaks.

Some other changes I work on (please let me know if you need them and I'll prepare PRs):
- technical thing: common practice - do not use "using namespace" in headers, because in this case the whole point of namespaces disappear. So I'll plan to remove such usings (in cc files "using" can be used)
- I added images processing using opencv (in current code there can be bugs, I still work on it) In this case we will not need dependences: jpeg, X11, CImg, tclap (I have removed them from opencv module already)
  Also I found bug, probably in CImg library, currently it added blue line on images borders. Using opencv I fixed it.
- I think we can remove function: init_random_from_state from cudamat.cu, as looks like it will never be used.
- I think we also can remove src\sample.cc, as it is not really related to the library code.

And maybe sometime in the future I think will be useful to add to this library all functionality from your other library: deepnet.
